### PR TITLE
Use deployment url as baseUrl 

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,4 @@
-baseurl = "/"
+baseurl = "https://ad-blog.cs.uni-freiburg.de/"
 languageCode = "en-US"
 canonifyurls = true
 


### PR DESCRIPTION

Apparently some feeds readers do not behave well with relative url, like the one you are using at the moment, with the `hugo.toml` line:
```
baseUrl="/"
```
Specifically `Nextcloud/News` app based on php library `feed-io` fails handle this, see https://github.com/nextcloud/news/issues/1385
Reading the the issues linked to that, somebody was pointing out using relative urls in rss-like output is not good practice, in fact the w3c validator does complain: https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fad-blog.cs.uni-freiburg.de%2Fpost%2Findex.xml

I am not an expert in Hugo nor in RSS feeds but using absolute baseUrl is fixing the problem, to the extend of my testing.